### PR TITLE
fix: probablerobot.net required checks

### DIFF
--- a/probablerobot-net.tf
+++ b/probablerobot-net.tf
@@ -8,10 +8,24 @@ module "probablerobot-net" {
   # github_repository_ruleset required_status_checks
   required_checks = [
     {
-      context = "check"
+      context        = "Header rules"
+      integration_id = 13473
     },
     {
-      context = "no-fixups"
+      context        = "Pages changed"
+      integration_id = 13473
     },
+    {
+      context        = "Redirect rules"
+      integration_id = 13473
+    },
+    {
+      context        = "check"
+      integration_id = 15368
+    },
+    {
+      context        = "no-fixups"
+      integration_id = 15368
+    }
   ]
 }


### PR DESCRIPTION
Update the integration_ids for the checks for probablerobot.net