### PR TITLE
fix: lab.probablerobot.net required checks

### DIFF
--- a/lab-probablerobot-net.tf
+++ b/lab-probablerobot-net.tf
@@ -8,7 +8,24 @@ module "lab-probablerobot-net" {
   # github_repository_ruleset required_status_checks
   required_checks = [
     {
-      context = "no-fixups"
+      context        = "Header rules"
+      integration_id = 13473
     },
+    {
+      context        = "Pages changed"
+      integration_id = 13473
+    },
+    {
+      context        = "Redirect rules"
+      integration_id = 13473
+    },
+    {
+      context        = "lint"
+      integration_id = 15368
+    },
+    {
+      context        = "no-fixups"
+      integration_id = 15368
+    }
   ]
 }


### PR DESCRIPTION
Update the required checks for lab.probablerobot.net