### PR TITLE
fix: remove Netlify checks

### DIFF
--- a/lab-probablerobot-net.tf
+++ b/lab-probablerobot-net.tf
@@ -7,18 +7,18 @@ module "lab-probablerobot-net" {
 
   # github_repository_ruleset required_status_checks
   required_checks = [
-    {
-      context        = "Header rules"
-      integration_id = 13473
-    },
-    {
-      context        = "Pages changed"
-      integration_id = 13473
-    },
-    {
-      context        = "Redirect rules"
-      integration_id = 13473
-    },
+    #{
+    #context        = "Header rules"
+    #integration_id = 13473
+    #},
+    #{
+    #context        = "Pages changed"
+    #integration_id = 13473
+    #},
+    #{
+    #context        = "Redirect rules"
+    #integration_id = 13473
+    #},
     {
       context        = "lint"
       integration_id = 15368

--- a/probablerobot-net.tf
+++ b/probablerobot-net.tf
@@ -7,18 +7,18 @@ module "probablerobot-net" {
 
   # github_repository_ruleset required_status_checks
   required_checks = [
-    {
-      context        = "Header rules"
-      integration_id = 13473
-    },
-    {
-      context        = "Pages changed"
-      integration_id = 13473
-    },
-    {
-      context        = "Redirect rules"
-      integration_id = 13473
-    },
+    #{
+    #  context        = "Header rules"
+    #  integration_id = 13473
+    #},
+    #{
+    #  context        = "Pages changed"
+    #  integration_id = 13473
+    #},
+    #{
+    #  context        = "Redirect rules"
+    #  integration_id = 13473
+    #},
     {
       context        = "check"
       integration_id = 15368


### PR DESCRIPTION
Disable the Netlify checks to see if this will allow Dependabot to merge its pull requests again using `@dependabot merge`.