### PR TITLE
chore: prevent_destroy

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -53,6 +53,10 @@ resource "github_repository" "this" {
       status = var.secret_scanning_push_protection_status
     }
   }
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "github_branch" "this" {


### PR DESCRIPTION
Repositories are very long lived and will probably never be destroyed using Terraform so add `lifecyle` to prevent accidentally destroying them.