### PR TITLE
chore: allow squash-merge

### DIFF
--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -24,7 +24,7 @@ variable "allow_rebase_merge" {
 variable "allow_squash_merge" {
   description = "(optional) Set to `true` to allow squash merges."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "allow_update_branch" {


### PR DESCRIPTION
Dependabot needs `allow_squash_merge` to be able to respond to approvals with an `@dependabot merge` message, so default this to `true`.