### PR TITLE
chore: remove branch

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -59,16 +59,10 @@ resource "github_repository" "this" {
   }
 }
 
-resource "github_branch" "this" {
-  repository = github_repository.this.name
-
-  branch = var.default_branch
-}
-
 resource "github_branch_default" "this" {
   repository = github_repository.this.name
 
-  branch = github_branch.this.branch
+  branch = var.default_branch
 }
 
 resource "github_repository_dependabot_security_updates" "this" {


### PR DESCRIPTION
Remove the github_branch resource. This is used to create new branches and it seems it should not be used to create a default branch. This is what the github_branch_default resource is for so we set that to `var.default_branch`