### PR TITLE
chore: rename default branch

### DIFF
--- a/matijs-github-io.tf
+++ b/matijs-github-io.tf
@@ -3,8 +3,6 @@ module "matijs-github-io" {
 
   name = "matijs.github.io"
 
-  default_branch = "master"
-
   pages = {
     build_type = "legacy"
     source = {

--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -59,10 +59,17 @@ resource "github_repository" "this" {
   }
 }
 
+# get the current state of the repository
+data "github_repository" "this" {
+  name = github_repository.this.name
+}
+
 resource "github_branch_default" "this" {
   repository = github_repository.this.name
 
   branch = var.default_branch
+  # check if the current name of the default branch is different from the desired name
+  rename = data.github_repository.this.default_branch != var.default_branch
 }
 
 resource "github_repository_dependabot_security_updates" "this" {


### PR DESCRIPTION
Add a github_repository data source so the current state of the repository can be retrieved.

If the name of the default branch differs from the potentially new name of the default branch, set `rename` to true in the github_branch_default resource.