### PR TITLE
chore: explicitly protect main branch

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -87,7 +87,7 @@ resource "github_repository_ruleset" "default" {
 
   conditions {
     ref_name {
-      include = ["~DEFAULT_BRANCH"]
+      include = ["~DEFAULT_BRANCH", "refs/heads/main"]
       exclude = []
     }
   }


### PR DESCRIPTION
Explicitly add "refs/heads/main" to the default branch protection ruleset.