### PR TITLE
chore: rename renovate -> renovate-config

### DIFF
--- a/renovate-config.tf
+++ b/renovate-config.tf
@@ -1,6 +1,6 @@
-module "renovate" {
+module "renovate-config" {
   source = "./modules/repository"
 
-  name        = "renovate"
+  name        = "renovate-config"
   description = "Renovate configuration"
 }


### PR DESCRIPTION
`{{parentOrg}}/renovate-config` with a file `default.json` is a file that can automatically be detected by Renovate, so rename the repo accordingly.