### PR TITLE
chore: update vulnerability alerts

### DIFF
--- a/modules/repository/main.tf
+++ b/modules/repository/main.tf
@@ -18,7 +18,6 @@ resource "github_repository" "this" {
   homepage_url           = var.homepage_url
   topics                 = var.topics
   visibility             = var.visibility
-  vulnerability_alerts   = var.vulnerability_alerts
 
   dynamic "pages" {
     for_each = var.pages != null ? [var.pages] : []
@@ -75,6 +74,12 @@ resource "github_repository_dependabot_security_updates" "this" {
   repository = github_repository.this.name
 
   enabled = var.dependabot_security_updates_enabled
+}
+
+resource "github_repository_vulnerability_alerts" "this" {
+  repository = github_repository.this.name
+
+  enabled = var.vulnerability_alerts_enabled
 }
 
 resource "github_repository_ruleset" "default" {

--- a/modules/repository/variables.tf
+++ b/modules/repository/variables.tf
@@ -105,7 +105,7 @@ variable "visibility" {
   default     = "public"
 }
 
-variable "vulnerability_alerts" {
+variable "vulnerability_alerts_enabled" {
   description = "(optional) Set to `false` to disable security alerts for vulnerable dependencies."
   type        = bool
   default     = true


### PR DESCRIPTION
- Remove `vulnerability_alerts` from the `github_repository` resource.
- Rename the `vulnerability_alerts` variable to `vulnerability_alerts_enabled` (in line with `dependabot_security_updates_enabled).
- Add the new `github_repository_vulnerability_alerts` resource.