### PR TITLE
ci: add zizmore to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - uses: matijs/no-fixups-action@8dfcf79304e29c3aa37e327cfc1d3685dca3c6c0 # v1.1.4
 
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+
   terraform:
     name: Terraform format check
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add the zizmorecore/zizmore-action GitHub Action to the CI workflow.